### PR TITLE
Close issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Charter proposal for a LOOPS WG, version 0.4.2
+# Charter proposal for a LOOPS WG, version 0.5
 
 ## Background
 
@@ -26,9 +26,7 @@ optimization protocol to run between these nodes.  Many end-to-end
 flows can be aggregated into each such tunnel flow being optimized.
 
 Initially, LOOPS will focus on path segments that do not include
-either end host, and where the primary congestion signaling method is
-ECN (which typically requires all routes on the path segment to be
-ECN-enabled).  Also, multipath forwarding will not be specifically
+either end host.  Also, multipath forwarding will not be specifically
 addressed and is left for future consideration.
 
 The selection of the segments to be optimized and the nodes that will


### PR DESCRIPTION
Based on the discussion on the list, I removed the restriction to ECN-enabled (all routers) path segments.

This puts us clearly on the "drop-to-mark" use case — ECN marks on the segment will be forwarded, but we also convert drops into marks by marking recovered packets.
This means end-to-end flows will not benefit from fewer congestion events (which would enhance their throughput), but will benefit from quick recovery (which will help reduce latency).
